### PR TITLE
Fixing "go vet" problem: "+build comment must..."

### DIFF
--- a/libusb.go
+++ b/libusb.go
@@ -1,3 +1,5 @@
+// +build linux,cgo darwin,!ios,cgo windows,cgo
+
 //-----------------------------------------------------------------------------
 /*
 
@@ -12,8 +14,6 @@ Copyright (c) 2017 Jason T. Harris
 package usbhid
 
 /*
-// +build linux,cgo darwin,!ios,cgo windows,cgo
-
 #include "./c/libusb/libusb.h"
 
 // When a C struct ends with a zero-sized field, but the struct itself is not zero-sized,


### PR DESCRIPTION
```
libusb.go:15: +build comment must appear before package clause and be followed by a blank line
```

 I also tried to make it [this](https://raw.githubusercontent.com/xaionaro-go/cryptoWallet/fa81c0805f56569807b3c0786c5fc8977f7e836b/vendor/github.com/trezor/usbhid/libusb.go) way but it didn't help.